### PR TITLE
Use custom readiness probe

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -29,6 +29,14 @@ spec:
                 key: pgadmin-password
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: {{ .Values.service.internalPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 15
+            failureThreshold: 5
           volumeMounts:
           - name: pgadmin-data
             mountPath: /var/lib/pgadmin4


### PR DESCRIPTION
K8s uses a `GET /` in its default readiness probe, which is used to determine whether the service should be routed to by an Ingress object.

`pgadmin` returns a 302 redirect to `/login` when you `GET /`. This is considered "unready" by k8s.

This patch adds a custom readiness probe which requests `/login` specifically.

`/login` is a route requiring dynamic work within `pgadmin` to serve, so it _shouldn't_ be used as a health-check endpoint like this, but it's the only route I was able to find in `pgadmin` that doesn't cause a 302 redirect to `/login` when not logged in. Even requests to static resources like images do, for some reason (I think maybe a lack of a `Referrer` header.) If you know of a `200`-returning endpoint in `pgadmin` that does less work, it would be better to modify the PR to use said endpoint instead.