### PR TITLE
Ingress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@ This is a single Helm chart that deploys a pgAdmin instance to your Kubernetes c
 ## Prerequisites
 This install assumes you have an existing Kubernetes cluster installed and a [postgresql](https://github.com/kubernetes/charts/tree/master/stable/postgresql) instance deployed.
 
+TLS support requires the [cert-manager](https://github.com/jetstack/cert-manager) Kubernetes add-on to be deployed into your cluster.
+
+## Chart Configuration
+
+The defaults in `values.yaml` will make your pgAdmin deployment accessible by its IP address over plaintext HTTP.
+
+To access your pgAdmin instance using a domain name over *plaintext HTTP*:
+
+1. set `service.type` to `NodePort`
+2. set `ingress.enabled` to `true`
+3. reserve a static IP address in your Kubernetes cluster (using e.g. `gcloud compute addresses create my-pgadmin-static-ip --global` for GCP)
+4. set `ingress.staticIPReservation` to the name of the static IP address reservation you created in step 3
+5. At your domain registrar, create an A record pointing to the static IP address you reserved in step 3
+
+To access your pgAdmin instance using a domain name over *HTTPS*, do the above steps, and as well:
+
+6. Set `ingress.tls.enabled` to `true`
+7. Set `ingress.tls.clusterIssuer` to the name of a [cert-manager](https://github.com/jetstack/cert-manager) `ClusterIssuer` deployed in your Kubernetes cluster
+8. Set `ingress.tls.externalDNSName` to the (fully-qualified) domain name you registered in step 5
+
 ## Package
 Once you've cloned this repo, you can create your helm package by running the following command in the repo's root directory:
 ```

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.staticIPReservation }}
+    {{- if .Values.ingress.tls.enabled }}
+    kubernetes.io/tls-acme: "true"
+    certmanager.k8s.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+  - secretName: {{ template "fullname" . }}-tls
+    hosts:
+    - {{ .Values.ingress.tls.externalDNSName }}
+  rules:
+  - host: {{ .Values.ingress.tls.externalDNSName }}
+    http:
+      paths:
+      - path: "/*"
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: {{ .Values.service.externalPort }}
+  {{- end }}
+  backend:
+    serviceName: {{ template "fullname" . }}
+    servicePort: {{ .Values.service.externalPort }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,13 @@ service:
   type: LoadBalancer
   externalPort: 5050
   internalPort: 5050
+ingress:
+  enabled: false
+  staticIPReservation: pgadmin-static-ip
+  tls:
+    enabled: false
+    clusterIssuer: letsencrypt-staging
+    externalDNSName: pgadmin.example.com
 pgadmin:
   username: pgadmin4@pgadmin.org
   #password: admin


### PR DESCRIPTION
This PR adds two things:

1. the ability to use a k8s `Ingress` object to connect to the deployed pgAdmin instance using a persistent static IP address (and therefore the ability to point a DNS record at the instance);
2. the ability to use a [cert-manager](https://github.com/jetstack/cert-manager) ClusterIssuer to automatically provision a TLS certificate for said `Ingress` object, such that the Ingress will then route HTTPS as well as HTTP traffic.

Note that, as is, `pgAdmin` will still think it's receiving HTTP traffic, it will sometimes create links or redirects that hardcode `http://` as their schema, switching the client away from HTTPS when these links/redirects are followed. Smart `IngressController`s (e.g. [ingress-nginx](https://github.com/kubernetes/ingress-nginx)) may automatically fix these up when the response passes through them. Dumber `IngressController`s (e.g. the load balancer of Google Cloud) won't.